### PR TITLE
remove pings, like, literally

### DIFF
--- a/src/main/scala/smartbot.scala
+++ b/src/main/scala/smartbot.scala
@@ -97,7 +97,7 @@ object SmartBot {
       getUsers(channel).foldLeft(message)({ (replaced, user) =>
         val nick = user.getNick()
         val mangled = nick.head + "." + nick.tail
-        replaced.replaceAll(nick, mangled)
+        replaced.replaceAllLiterally(nick, mangled)
       })
     }
 


### PR DESCRIPTION
replaceAll apparently takes a string formatted as a regex, so if someone
changes their nick to, for example, [a-z], the output is, like, totally
garbled.  Literally.
